### PR TITLE
Add documentation and pull some hardcoded variables into constants

### DIFF
--- a/examples/guild_list.rs
+++ b/examples/guild_list.rs
@@ -5,7 +5,7 @@ struct ExampleReadyHandler {
 }
 
 impl_event!(ExampleReadyHandler, ReadyEvent(this, client: (events::Client<'_>)) {
-    let user = client.get_user();
+    let user = client.get_current_user();
 
     println!("{}", this.welcome_text);
     println!("user: {}#{}", user.username, user.discriminator);

--- a/examples/ready.rs
+++ b/examples/ready.rs
@@ -8,7 +8,7 @@ struct ExampleHandler {
 // `this` can be anything but `self`  --v
 impl_event!(ExampleHandler, ReadyEvent(this, client: (events::Client<'_>)) {
     let client = client;
-    let user = client.get_user();
+    let user = client.get_current_user();
 
     println!("{}", this.welcome_text);
     println!("user: {}#{}", user.username, user.discriminator);

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -9,7 +9,16 @@ use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 
 const TMP_GATEWAY_SERIOUSLY_DYNAMICALLY_GET_THIS: &str = "wss://gateway.discord.gg";
-const API_PATH: &str = "https://discordapp.com/api/v6";
+
+/// The User-Agent of the discord bot that is used when interacting
+/// with the discord apis.
+///
+/// https://discordapp.com/developers/docs/reference#user-agent
+pub(crate) const USER_AGENT: &str = concat!(
+    "DiscordBot (https://github.com/Admicos/thatcord, ",
+    env!("CARGO_PKG_VERSION"),
+    ")"
+);
 
 struct DefaultEventHandler {
     events: HashMap<String, Box<dyn EventHandler>>,

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -149,7 +149,7 @@ where
     pub async fn new(gateway: &str, token: &str, event_handler: F) -> Result<Self> {
         let mut builder = ClientBuilder::new(&format!("{}?v=6&encoding=json", gateway))
             .context(GatewayClientBuildError)?;
-        builder.add_header("User-Agent".to_owned(), "admi#4273".to_owned());
+        builder.add_header("User-Agent".to_owned(), crate::discord::USER_AGENT.to_owned());
 
         if let Ok(client) = builder.async_connect().await {
             let (tx, rx) = watch::channel::<Option<u64>>(None);

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -23,8 +23,11 @@ enum DiscordState {
     Ready,
 }
 
+/// The opcode for a gateway event
+///
+/// https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#gateway-opcodes
 #[derive(Copy, Clone)]
-enum DiscordOpcodes {
+enum GatewayOpcodes {
     HEARTBEAT = 1,
     IDENTIFY = 2,
 }
@@ -56,7 +59,7 @@ async fn heartbeat(
         log::trace!("Sending heartbeat");
         if let Err(e) = send(
             client.lock().await.deref_mut(),
-            DiscordOpcodes::HEARTBEAT,
+            GatewayOpcodes::HEARTBEAT,
             serde_json::to_value(seq_channel.recv().await)
                 .expect("heartbeat sequence cannot be transformed into a JSON value"),
         )
@@ -100,7 +103,7 @@ where
     async fn op1_heartbeat(&mut self, _payload: gateway::Payload) -> Result<()> {
         let mut ch = self.heartbeat_seq_channel_recv.clone(); // Is this inefficient?
         self.send(
-            DiscordOpcodes::HEARTBEAT,
+            GatewayOpcodes::HEARTBEAT,
             serde_json::to_value(ch.recv().await).context(JsonConversionError)?,
         )
         .await
@@ -117,13 +120,13 @@ where
             });
 
             self.send(
-                DiscordOpcodes::IDENTIFY,
+                GatewayOpcodes::IDENTIFY,
                 json!({
                     "token": self.token,
                     "properties": {
                         "$os": std::env::consts::OS,
-                        "$browser": "admi#4273's wip discord rust client",
-                        "$device": "admi#4273's wip discord rust client"
+                        "$browser": crate::LIBRARY_IDENTITY,
+                        "$device": crate::LIBRARY_IDENTITY
                     }
                 }),
             )
@@ -212,14 +215,14 @@ where
         }
     }
 
-    async fn send(&mut self, opcode: DiscordOpcodes, data: serde_json::Value) -> Result<()> {
+    async fn send(&mut self, opcode: GatewayOpcodes, data: serde_json::Value) -> Result<()> {
         send(self.client.lock().await.deref_mut(), opcode, data).await
     }
 }
 
 async fn send(
     client: &mut WSClient,
-    opcode: DiscordOpcodes,
+    opcode: GatewayOpcodes,
     data: serde_json::Value,
 ) -> Result<()> {
     send_payload(

--- a/src/json/gateway.rs
+++ b/src/json/gateway.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// A gateway payload
+/// https://discordapp.com/developers/docs/topics/gateway#payloads
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct Payload {
     pub op: u8,

--- a/src/json/guild.rs
+++ b/src/json/guild.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-/// See tbe following official documentation for item descriptions.
+/// See the following official documentation for item descriptions.
 /// https://discordapp.com/developers/docs/resources/guild#guild-object
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Guild {

--- a/src/json/user.rs
+++ b/src/json/user.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+/// A Discord User
+/// https://discordapp.com/developers/docs/resources/user#user-object
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct User {
     pub id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,5 @@ pub mod events;
 pub use discord::Discord;
 pub use errors::{Error, Result};
 pub use json::{Guild, User};
+
+const LIBRARY_IDENTITY: &str = "Thatcord";


### PR DESCRIPTION
I added a bit of documentation for the parts of the discord api that I understand, and I changed some of the hardcoded names such as the User-Agent and the identify response into constants.

I also made an attempt at dynamically resolving the gateway on a seperate branch, but that requires adding an entire http client as a dependancy, so I'm unsure about how to aproach that.  (The main body of that implementation is here: https://github.com/Aeledfyr/thatcord/blob/http/src/json/gateway.rs)
I'm interested in this project (I have a large discord bot currently built on serenity-rs), and am willing to help when I have the time.