### PR TITLE
Extend the Discord API representation - Snowflake IDs & GatewayOpcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +750,7 @@ dependencies = [
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1017,6 +1028,7 @@ dependencies = [
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
+"checksum serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ websocket-lite = "0.3.2"
 futures-util = "0.3.1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_repr = "0.1.5"
 snafu = "0.6.0"
 url = "2.1.0"
 async-trait = "0.1.21"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,6 +33,9 @@ pub(crate) enum Errors {
     #[snafu(display("Unknown opcode received from Discord's gateway: {}", opcode))]
     GatewayUnknownOpcode { opcode: u8 },
 
+    #[snafu(display("Invalid opcode to recieve from Discord's gateway: {}", opcode))]
+    GatewayInvalidRecieveOpcode { opcode: u8 },
+
     #[snafu(display("Cannot connect to Discord's gateway"))]
     GatewayConnectError,
 

--- a/src/json/gateway.rs
+++ b/src/json/gateway.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_repr::{Serialize_repr, Deserialize_repr};
 use serde_json::Value;
 
 /// A gateway payload
@@ -9,4 +10,44 @@ pub(crate) struct Payload {
     pub d: Value,
     pub s: Option<u64>,
     pub t: Option<String>,
+}
+
+/// The opcode for a gateway event
+/// https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#gateway-opcodes
+#[derive(Copy, Clone, Debug)]
+#[derive(Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+#[non_exhaustive]
+pub(crate) enum GatewayOpcode {
+    Dispatch = 0,
+    Heartbeat = 1,
+    Identify = 2,
+    StatusUpdate = 3,
+    VoiceStateUpdate = 4,
+    Resume = 6,
+    Reconnect = 7,
+    RequestGuildMembers = 8,
+    InvalidSession = 9,
+    Hello = 10,
+    HeartbeatAck = 11,
+}
+
+impl std::convert::TryFrom<u8> for GatewayOpcode {
+    type Error = crate::errors::Errors;
+    fn try_from(op: u8) -> Result<GatewayOpcode, Self::Error> {
+        match op {
+            0 => Ok(GatewayOpcode::Dispatch),
+            1 => Ok(GatewayOpcode::Heartbeat),
+            2 => Ok(GatewayOpcode::Identify),
+            3 => Ok(GatewayOpcode::StatusUpdate),
+            4 => Ok(GatewayOpcode::VoiceStateUpdate),
+            6 => Ok(GatewayOpcode::Resume),
+            7 => Ok(GatewayOpcode::Reconnect),
+            8 => Ok(GatewayOpcode::RequestGuildMembers),
+            9 => Ok(GatewayOpcode::InvalidSession),
+            10 => Ok(GatewayOpcode::Hello),
+            11 => Ok(GatewayOpcode::HeartbeatAck),
+            op => Err(crate::errors::Errors::GatewayUnknownOpcode { opcode: op })
+        }
+    }
 }

--- a/src/json/guild.rs
+++ b/src/json/guild.rs
@@ -1,11 +1,15 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct GuildId(super::Id);
+
 /// See the following official documentation for item descriptions.
 /// https://discordapp.com/developers/docs/resources/guild#guild-object
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct Guild {
-    pub id: String,
+    pub id: GuildId,
     pub unavailable: bool,
 
     // The rest will only be created whenever Discord sends us a GUILD_CREATE event
@@ -23,7 +27,7 @@ pub struct Guild {
 
     pub member_count: Option<u64>,
 
-    pub owner_id: Option<String>,
+    pub owner_id: Option<super::UserId>,
     pub application_id: Option<String>,
 
     pub afk_channel_id: Option<String>,

--- a/src/json/guild.rs
+++ b/src/json/guild.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 /// See the following official documentation for item descriptions.
 /// https://discordapp.com/developers/docs/resources/guild#guild-object
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct Guild {
     pub id: String,
     pub unavailable: bool,

--- a/src/json/id.rs
+++ b/src/json/id.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+/// A discord snowflake id
+/// https://discordapp.com/developers/docs/reference#snowflakes
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(transparent)]
+pub(crate) struct Id(pub(crate) u64);
+
+impl Id {
+    /// Gets the timestamp that the snowflake id was created at (unix epoch)
+    // TODO: use chrono/time
+    pub fn get_timestamp(self) -> u64 {
+        (self.0 >> 22) + 1_420_070_400_000
+    }
+}
+
+impl std::str::FromStr for Id {
+    type Err = std::num::ParseIntError;
+    fn from_str(s: &str) -> Result<Id, Self::Err> {
+        s.parse::<u64>().map(Id)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum IdStringOrInt {
+    Integer(u64),
+    String(String),
+}
+impl<'de> serde::Deserialize<'de> for Id {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match IdStringOrInt::deserialize(deserializer)? {
+            IdStringOrInt::Integer(i) => Ok(Id(i)),
+            IdStringOrInt::String(s) => s
+                .parse::<u64>()
+                .map(Id)
+                .map_err(|_| serde::de::Error::custom("Expected integer in String format")),
+        }
+    }
+}

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod gateway;
 pub mod guild;
 pub mod user;
+mod id;
 
 pub use guild::*;
 pub use user::*;
+pub(crate) use id::Id;

--- a/src/json/user.rs
+++ b/src/json/user.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 /// A Discord User
 /// https://discordapp.com/developers/docs/resources/user#user-object
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct User {
     pub id: String,
     pub username: String,

--- a/src/json/user.rs
+++ b/src/json/user.rs
@@ -1,11 +1,15 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct UserId(super::Id);
+
 /// A Discord User
 /// https://discordapp.com/developers/docs/resources/user#user-object
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct User {
-    pub id: String,
+    pub id: UserId,
     pub username: String,
     pub discriminator: String,
 


### PR DESCRIPTION
At some point in the future I plan on working on setting up some more of the structures from the discord API, and then afterwards connecting that up with http/api calls.