### PR TITLE
Add permission support and fix some bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ name = "thatcord"
 version = "0.1.0"
 dependencies = [
  "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ url = "2.1.0"
 async-trait = "0.1.21"
 paste = "0.1.6"
 surf = "1.0"
+bitflags = "1.2"
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/src/api/channel.rs
+++ b/src/api/channel.rs
@@ -38,8 +38,8 @@ pub struct PermissionOverwrite {
     /// "role" or "user"
     #[serde(rename = "type")]
     pub kind: String,
-    pub allow: u64,
-    pub deny: u64,
+    pub allow: super::permissions::Permissions,
+    pub deny: super::permissions::Permissions,
 }
 
 #[derive(Serialize_repr, Deserialize_repr, Debug, Clone, PartialEq, Eq)]
@@ -485,8 +485,8 @@ pub async fn bulk_delete_message(
 
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct EditChannelPermission {
-    pub allow: u64,
-    pub deny: u64,
+    pub allow: super::permissions::Permissions,
+    pub deny: super::permissions::Permissions,
     #[serde(rename = "type")]
     pub kind: String, // "member" or "role"
 }

--- a/src/api/guild.rs
+++ b/src/api/guild.rs
@@ -43,7 +43,7 @@ pub struct Guild {
     pub vanity_url_code: Option<String>,
     pub preferred_locale: Option<String>,
 
-    pub permissions: Option<u64>,
+    pub permissions: Option<super::permissions::Permissions>,
 
     pub premium_subscription_count: Option<u64>,
 
@@ -70,8 +70,8 @@ pub struct Guild {
     pub members: Option<Vec<GuildMember>>,
     pub voice_states: Option<Vec<VoiceState>>,
 
-    pub emojis: Vec<super::channel::Emoji>,
-    pub roles: Vec<Role>,
+    pub emojis: Option<Vec<super::channel::Emoji>>,
+    pub roles: Option<Vec<Role>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -94,7 +94,7 @@ pub struct Role {
     pub color: u64,
     pub hoist: bool,
     pub position: u64,
-    pub permissions: u64,
+    pub permissions: super::permissions::Permissions,
     pub managed: bool,
     pub mentionable: bool,
 }
@@ -102,12 +102,12 @@ pub struct Role {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct PresenceUpdate {
-    pub user: serde_json::Value,
-    pub roles: Vec<RoleId>,
+    pub user: Option<serde_json::Value>,
+    pub roles: Option<Vec<RoleId>>,
     pub game: Option<Activity>,
-    pub guild_id: GuildId,
-    pub status: OnlineStatus,
-    pub activities: Vec<Activity>,
+    pub guild_id: Option<GuildId>,
+    pub status: Option<OnlineStatus>,
+    pub activities: Option<Vec<Activity>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -481,7 +481,7 @@ pub async fn get_guild_roles(token: &str, guild: GuildId) -> Result<Vec<Role>> {
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct CreateRole {
     pub name: String,
-    pub permissions: u64,
+    pub permissions: super::permissions::Permissions,
     pub color: u64,
     pub hoist: bool,
     pub mentionable: bool,
@@ -506,7 +506,7 @@ pub async fn modify_role_order(
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ModifyRole {
     pub name: Option<String>,
-    pub permissions: Option<u64>,
+    pub permissions: Option<super::permissions::Permissions>,
     pub color: Option<u64>,
     pub hoist: Option<bool>,
     pub mentionable: Option<bool>,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,6 +13,7 @@ pub mod gateway;
 pub mod guild;
 pub mod id;
 pub mod user;
+pub mod permissions;
 
 #[cfg(test)]
 mod tests;

--- a/src/api/permissions.rs
+++ b/src/api/permissions.rs
@@ -1,0 +1,38 @@
+
+
+bitflags::bitflags! {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(transparent)]
+    pub struct Permissions: u64 {
+        const CREATE_INSTANT_INVITE = 0x00000001;
+        const KICK_MEMBERS = 0x00000002;
+        const BAN_MEMBERS = 0x00000004;
+        const ADMINISTRATOR = 0x00000008;
+        const MANAGE_CHANNELS = 0x00000010;
+        const MANAGE_GUILD = 0x00000020;
+        const ADD_REACTIONS = 0x00000040;
+        const VIEW_AUDIT_LOG = 0x00000080;
+        const PRIORITY_SPEAKER = 0x00000100;
+        const STREAM = 0x00000200;
+        const VIEW_CHANNEL = 0x00000400;
+        const SEND_MESSAGES = 0x00000800;
+        const SEND_TTS_MESSAGES = 0x00001000;
+        const MANAGE_MESSAGES = 0x00002000;
+        const EMBED_LINKS = 0x00004000;
+        const ATTACH_FILES = 0x00008000;
+        const READ_MESSAGE_HISTORY = 0x00010000;
+        const MENTION_EVERYONE = 0x00020000;
+        const USE_EXTERNAL_EMOJIS = 0x00040000;
+        const CONNECT = 0x00100000;
+        const SPEAK = 0x00200000;
+        const MUTE_MEMBERS = 0x00400000;
+        const DEAFEN_MEMBERS = 0x00800000;
+        const MOVE_MEMBERS = 0x01000000;
+        const USE_VAD = 0x02000000;
+        const CHANGE_NICKNAME = 0x04000000;
+        const MANAGE_NICKNAMES = 0x08000000;
+        const MANAGE_ROLES = 0x10000000;
+        const MANAGE_WEBHOOKS = 0x20000000;
+        const MANAGE_EMOJIS = 0x40000000;
+    }
+}


### PR DESCRIPTION
This adds permissions support through the `bitflags` crate, and fixes a few bugs in the partial representation of guilds.  I'm not certain if we should split the partial and full representations of things like Guilds or Users, which would help avoid this sort of issue.
This also includes a patch to avoid displaying the discord token in the logging output.