### PR TITLE
Move websocket handling to a worker thread

### DIFF
--- a/src/api/gateway.rs
+++ b/src/api/gateway.rs
@@ -5,7 +5,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 /// A gateway payload
 /// https://discordapp.com/developers/docs/topics/gateway#payloads
 #[derive(Serialize, Deserialize, Debug)]
-pub(crate) struct Payload {
+pub struct Payload {
     pub op: u8,
     pub d: Value,
     pub s: Option<u64>,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12,8 +12,8 @@ pub mod channel;
 pub mod gateway;
 pub mod guild;
 pub mod id;
-pub mod user;
 pub mod permissions;
+pub mod user;
 
 #[cfg(test)]
 mod tests;
@@ -158,7 +158,7 @@ async fn handle_errors<T: serde::de::DeserializeOwned>(
     if response.status().is_success() {
         Ok(response.body_json().await?)
     } else {
-        Err(errors::DiscordError::ApiError(response.body_json::<ApiError>().await?).into())
+        Err(errors::DiscordError::ApiError(response.body_json::<ApiError>().await?))
     }
 }
 

--- a/src/api/permissions.rs
+++ b/src/api/permissions.rs
@@ -1,38 +1,36 @@
-
-
 bitflags::bitflags! {
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(transparent)]
     pub struct Permissions: u64 {
-        const CREATE_INSTANT_INVITE = 0x00000001;
-        const KICK_MEMBERS = 0x00000002;
-        const BAN_MEMBERS = 0x00000004;
-        const ADMINISTRATOR = 0x00000008;
-        const MANAGE_CHANNELS = 0x00000010;
-        const MANAGE_GUILD = 0x00000020;
-        const ADD_REACTIONS = 0x00000040;
-        const VIEW_AUDIT_LOG = 0x00000080;
-        const PRIORITY_SPEAKER = 0x00000100;
-        const STREAM = 0x00000200;
-        const VIEW_CHANNEL = 0x00000400;
-        const SEND_MESSAGES = 0x00000800;
-        const SEND_TTS_MESSAGES = 0x00001000;
-        const MANAGE_MESSAGES = 0x00002000;
-        const EMBED_LINKS = 0x00004000;
-        const ATTACH_FILES = 0x00008000;
-        const READ_MESSAGE_HISTORY = 0x00010000;
-        const MENTION_EVERYONE = 0x00020000;
-        const USE_EXTERNAL_EMOJIS = 0x00040000;
-        const CONNECT = 0x00100000;
-        const SPEAK = 0x00200000;
-        const MUTE_MEMBERS = 0x00400000;
-        const DEAFEN_MEMBERS = 0x00800000;
-        const MOVE_MEMBERS = 0x01000000;
-        const USE_VAD = 0x02000000;
-        const CHANGE_NICKNAME = 0x04000000;
-        const MANAGE_NICKNAMES = 0x08000000;
-        const MANAGE_ROLES = 0x10000000;
-        const MANAGE_WEBHOOKS = 0x20000000;
-        const MANAGE_EMOJIS = 0x40000000;
+        const CREATE_INSTANT_INVITE = 0x0000_0001;
+        const KICK_MEMBERS      = 0x0000_0002;
+        const BAN_MEMBERS       = 0x0000_0004;
+        const ADMINISTRATOR     = 0x0000_0008;
+        const MANAGE_CHANNELS   = 0x0000_0010;
+        const MANAGE_GUILD      = 0x0000_0020;
+        const ADD_REACTIONS     = 0x0000_0040;
+        const VIEW_AUDIT_LOG    = 0x0000_0080;
+        const PRIORITY_SPEAKER  = 0x0000_0100;
+        const STREAM            = 0x0000_0200;
+        const VIEW_CHANNEL      = 0x0000_0400;
+        const SEND_MESSAGES     = 0x0000_0800;
+        const SEND_TTS_MESSAGES = 0x0000_1000;
+        const MANAGE_MESSAGES   = 0x0000_2000;
+        const EMBED_LINKS       = 0x0000_4000;
+        const ATTACH_FILES      = 0x0000_8000;
+        const READ_MESSAGE_HISTORY = 0x0001_0000;
+        const MENTION_EVERYONE     = 0x0002_0000;
+        const USE_EXTERNAL_EMOJIS  = 0x0004_0000;
+        const CONNECT          = 0x0010_0000;
+        const SPEAK            = 0x0020_0000;
+        const MUTE_MEMBERS     = 0x0040_0000;
+        const DEAFEN_MEMBERS   = 0x0080_0000;
+        const MOVE_MEMBERS     = 0x0100_0000;
+        const USE_VAD          = 0x0200_0000;
+        const CHANGE_NICKNAME  = 0x0400_0000;
+        const MANAGE_NICKNAMES = 0x0800_0000;
+        const MANAGE_ROLES     = 0x1000_0000;
+        const MANAGE_WEBHOOKS  = 0x2000_0000;
+        const MANAGE_EMOJIS    = 0x4000_0000;
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -50,7 +50,7 @@ impl DefaultEventHandler {
     }
 
     /// A handler function that runs before any of the registered event handlers
-    /// run when a "READY" event is recieved.
+    /// run when a "READY" event is received.
     fn pre_ready(&mut self, data: &serde_json::Value) -> Result<()> {
         let c = self
             .client
@@ -69,7 +69,7 @@ impl DefaultEventHandler {
     }
 
     /// A handler function that runs before any of the registered event handlers
-    /// run when a "GUILD_CREATE" event is recieved.
+    /// run when a "GUILD_CREATE" event is received.
     fn pre_guild_create(&mut self, data: &serde_json::Value) -> Result<()> {
         let c = self
             .client

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,8 @@ pub enum DiscordError {
     HttpError(surf::Exception),
     IoError(std::io::Error),
     HeartbeatSeqUpdateError(tokio::sync::watch::error::SendError<Option<u64>>),
+    SocketThread(tokio::sync::mpsc::error::SendError<crate::api::gateway::Payload>),
+    HeartbeatTimeError(tokio::sync::watch::error::SendError<std::time::Instant>),
     ApiError(crate::api::ApiError),
     GatewayError(GatewayError),
 }
@@ -32,6 +34,8 @@ impl std::fmt::Display for DiscordError {
             Self::HeartbeatSeqUpdateError(ref e) => {
                 write!(f, "Heartbeat sequence update error: {}", e)
             }
+            Self::HeartbeatTimeError(ref e) => write!(f, "Heartbeat time update error: {}", e),
+            Self::SocketThread(ref e) => write!(f, "Socket thread communcation failiure: {}", e),
             Self::GatewayError(ref e) => write!(f, "Gateway error: {}", e),
         }
     }
@@ -45,6 +49,11 @@ convert_error!(
     tokio::sync::watch::error::SendError<Option<u64>>,
     DiscordError,
     HeartbeatSeqUpdateError
+);
+convert_error!(
+    tokio::sync::mpsc::error::SendError<crate::api::gateway::Payload>,
+    DiscordError,
+    SocketThread
 );
 convert_error!(GatewayError, DiscordError, GatewayError);
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,7 +17,7 @@ pub enum DiscordError {
     HttpError(surf::Exception),
     IoError(std::io::Error),
     HeartbeatSeqUpdateError(tokio::sync::watch::error::SendError<Option<u64>>),
-    SocketThread(tokio::sync::mpsc::error::SendError<crate::api::gateway::Payload>),
+    SocketThreadError(tokio::sync::mpsc::error::SendError<crate::api::gateway::Payload>),
     HeartbeatTimeError(tokio::sync::watch::error::SendError<std::time::Instant>),
     ApiError(crate::api::ApiError),
     GatewayError(GatewayError),
@@ -35,7 +35,9 @@ impl std::fmt::Display for DiscordError {
                 write!(f, "Heartbeat sequence update error: {}", e)
             }
             Self::HeartbeatTimeError(ref e) => write!(f, "Heartbeat time update error: {}", e),
-            Self::SocketThread(ref e) => write!(f, "Socket thread communcation failiure: {}", e),
+            Self::SocketThreadError(ref e) => {
+                write!(f, "Socket thread communcation failiure: {}", e)
+            }
             Self::GatewayError(ref e) => write!(f, "Gateway error: {}", e),
         }
     }
@@ -53,7 +55,7 @@ convert_error!(
 convert_error!(
     tokio::sync::mpsc::error::SendError<crate::api::gateway::Payload>,
     DiscordError,
-    SocketThread
+    SocketThreadError
 );
 convert_error!(GatewayError, DiscordError, GatewayError);
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -259,7 +259,7 @@ where
         } else {
             Err(GatewayError::InvalidResponseError {
                 what: "Hello does not have heartbeat_interval".to_owned(),
-            })?
+            }.into())
         }
     }
 
@@ -277,7 +277,7 @@ where
 
     pub async fn new(gateway: &str, token: &str, event_handler: F) -> Result<Self> {
         let mut builder = ClientBuilder::new(&format!("{}?v=6&encoding=json", gateway))
-            .map_err(|e| GatewayError::from(e))?;
+            .map_err(GatewayError::from)?;
 
         builder.add_header(
             "User-Agent".to_owned(),
@@ -313,7 +313,7 @@ where
                 heartbeat_handler: handler,
             })
         } else {
-            Err(GatewayError::ConnectError)?
+            Err(GatewayError::ConnectError.into())
         }
     }
 
@@ -336,7 +336,7 @@ where
             GatewayOpcode::InvalidSession => self.op9_invalid_session(payload).await,
             GatewayOpcode::Hello => self.op10_hello(payload).await,
             GatewayOpcode::HeartbeatAck => self.op11_heartbeat_ack(payload).await,
-            _ => Err(GatewayError::UnknownOpcode { opcode: payload.op })?,
+            _ => Err(GatewayError::UnknownOpcode { opcode: payload.op }.into()),
         }
     }
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,14 +1,14 @@
 use crate::api::gateway;
 use crate::errors::{GatewayError, Result};
 use async_trait::async_trait;
-use futures_util::stream::StreamExt;
-use futures_util::SinkExt;
 use serde_json::json;
-use tokio::sync::watch;
-use tokio::time;
-use websocket_lite::{AsyncClient, AsyncNetworkStream, ClientBuilder, Message};
+use websocket_lite::ClientBuilder;
 
-type WSClient = AsyncClient<Box<dyn AsyncNetworkStream + Send + Sync + Unpin>>;
+mod heartbeat;
+mod socket;
+
+use heartbeat::{heartbeat, HeartbeatHandler, HeartbeatSender};
+use socket::{Client, Connection};
 
 #[async_trait(?Send)]
 pub(crate) trait EventHandler {
@@ -35,162 +35,6 @@ where
 
     heartbeat_sender: HeartbeatSender,
     heartbeat_handler: HeartbeatHandler,
-}
-
-pub(crate) struct Client {
-    pub send: tokio::sync::mpsc::UnboundedSender<gateway::Payload>,
-    pub receive: tokio::sync::mpsc::UnboundedReceiver<gateway::Payload>,
-}
-
-impl Client {
-    fn send(&mut self, op: gateway::GatewayOpcode, value: serde_json::Value) -> Result<()> {
-        self.send.send(gateway::Payload {
-            op: op as u8,
-            d: value,
-            t: None,
-            s: None,
-        })?;
-        Ok(())
-    }
-}
-
-pub(crate) struct Connection {
-    socket: futures_util::stream::Fuse<WSClient>,
-    send: tokio::sync::mpsc::UnboundedSender<gateway::Payload>, // Linked to Client.receive
-    receive: futures_util::stream::Fuse<tokio::sync::mpsc::UnboundedReceiver<gateway::Payload>>, // Linked to Client.send
-    disconnect: futures_util::stream::Fuse<tokio::sync::mpsc::UnboundedReceiver<bool>>, // Linked to Client.send
-}
-
-impl Connection {
-    /// Creates a new Connection structure, which will be used once
-    /// to start the socket handler, and a Client structure, which
-    /// holds the queues for communication.
-    pub(crate) fn new(
-        socket: WSClient,
-        disconnect: tokio::sync::mpsc::UnboundedReceiver<bool>,
-    ) -> (Self, Client) {
-        let (client_send, receive) = tokio::sync::mpsc::unbounded_channel();
-        let (send, client_receive) = tokio::sync::mpsc::unbounded_channel();
-
-        (
-            Self {
-                send,
-                receive: receive.fuse(),
-                socket: socket.fuse(),
-                disconnect: disconnect.fuse(),
-            },
-            Client {
-                send: client_send,
-                receive: client_receive,
-            },
-        )
-    }
-
-    /// Starts the socket handling loop, and immediately returns
-    /// The handler is run through a spawned future (tokio::spawn)
-    pub(crate) fn run(mut self) {
-        tokio::spawn(async move {
-            loop {
-                futures_util::select! {
-                    disconnect = self.disconnect.select_next_some() => {
-                        if disconnect {
-                            self.socket.send(Message::close(Some((4000, String::new())))).await?;
-                            self.socket.close().await?;
-                            log::error!("Disconnecting from gateway");
-                            break;
-                        }
-                    }
-                    payload = self.socket.select_next_some() => {
-                        match payload {
-                            Ok(payload) => {
-                                log::trace!("discord raw payload {:?}", payload);
-
-                                if let Some(data) = payload.as_text() {
-                                    let payload: gateway::Payload = serde_json::from_str::<gateway::Payload>(data)?;
-                                    self.send.send(payload)?;
-                                } else {
-                                    log::error!("Discord weird payload: {:?}", payload);
-                                }
-                            }
-                            Err(e) => log::error!("Discord error: {}", e),
-                        }
-                    }
-                    payload = self.receive.select_next_some() => {
-                        send(payload, &mut self.socket).await?;
-                    }
-                }
-            }
-            Ok::<(), crate::errors::DiscordError>(())
-        });
-    }
-}
-
-async fn send(
-    mut payload: gateway::Payload,
-    socket: &mut futures_util::stream::Fuse<WSClient>,
-) -> Result<()> {
-    let payload_str = serde_json::to_string(&payload)?;
-
-    // Don't log the discord token
-    if payload.op == GatewayOpcode::Identify as u8 {
-        if let Some(token) = payload.d.get_mut("token") {
-            *token = serde_json::json!("<TOKEN REDACTED>");
-        }
-        log::trace!(
-            "sending gateway payload: {}",
-            serde_json::to_string(&payload)?
-        );
-    } else {
-        log::trace!("sending gateway payload: {}", payload_str);
-    }
-    socket.send(Message::text(payload_str)).await?;
-    Ok(())
-}
-
-struct HeartbeatSender {
-    last_seq: watch::Sender<Option<u64>>,
-    last_ack: watch::Sender<std::time::Instant>,
-}
-
-#[derive(Clone)]
-struct HeartbeatHandler {
-    last_seq: watch::Receiver<Option<u64>>,
-    last_send: std::time::Instant,
-    last_ack: watch::Receiver<std::time::Instant>,
-    disconnect: tokio::sync::mpsc::UnboundedSender<bool>,
-}
-
-async fn heartbeat(
-    client: tokio::sync::mpsc::UnboundedSender<gateway::Payload>,
-    heartbeat_interval: u64,
-    mut handler: HeartbeatHandler,
-) {
-    let mut interval = time::interval(time::Duration::from_millis(heartbeat_interval));
-
-    loop {
-        interval.tick().await;
-
-        if *handler.last_ack.borrow() < handler.last_send {
-            // Break connection
-            log::error!("No response for heartbeat, reconnecting");
-            handler.disconnect.send(true).unwrap();
-            break;
-        }
-
-        handler.last_send = std::time::Instant::now();
-
-        log::trace!("Sending heartbeat");
-        let value: serde_json::Value = serde_json::to_value(*handler.last_seq.borrow())
-            .expect("heartbeat sequence cannot be transformed into a JSON value");
-        if let Err(e) = client.send(gateway::Payload {
-            op: GatewayOpcode::Heartbeat as u8,
-            d: value,
-            s: None,
-            t: None,
-        }) {
-            log::error!("Cannot send heartbeat to Discord: {}", e);
-        }
-    }
 }
 
 impl<F> Gateway<F>
@@ -259,7 +103,8 @@ where
         } else {
             Err(GatewayError::InvalidResponseError {
                 what: "Hello does not have heartbeat_interval".to_owned(),
-            }.into())
+            }
+            .into())
         }
     }
 
@@ -285,21 +130,10 @@ where
         );
 
         if let Ok(client) = builder.async_connect().await {
-            let start = std::time::Instant::now();
-            let (last_ack_tx, last_ack_rx) = watch::channel::<std::time::Instant>(start);
-            let (last_seq_tx, last_seq_rx) = watch::channel::<Option<u64>>(None);
             let (disconnect_tx, disconnect_rx) = tokio::sync::mpsc::unbounded_channel::<bool>();
-            let handler = HeartbeatHandler {
-                last_ack: last_ack_rx,
-                last_seq: last_seq_rx,
-                last_send: start,
-                disconnect: disconnect_tx,
-            };
-            let sender = HeartbeatSender {
-                last_ack: last_ack_tx,
-                last_seq: last_seq_tx,
-            };
             let (connection, client) = Connection::new(client, disconnect_rx);
+            let (handler, sender) = HeartbeatHandler::new(disconnect_tx);
+
             Ok(Gateway {
                 token: token.to_owned(),
                 client,
@@ -320,7 +154,7 @@ where
     pub(crate) async fn handle(&mut self) -> Result<()> {
         let socket = self.socket.take().expect("Handle can only be run once");
         socket.run();
-        while let Some(payload) = self.client.receive.recv().await {
+        while let Some(payload) = self.client.receive().await {
             self.handle_payload(payload).await?;
         }
         Ok(())

--- a/src/gateway/heartbeat.rs
+++ b/src/gateway/heartbeat.rs
@@ -1,0 +1,70 @@
+use crate::api::gateway;
+use tokio::sync::watch;
+
+pub struct HeartbeatSender {
+    pub last_seq: watch::Sender<Option<u64>>,
+    pub last_ack: watch::Sender<std::time::Instant>,
+}
+
+#[derive(Clone)]
+pub struct HeartbeatHandler {
+    pub last_seq: watch::Receiver<Option<u64>>,
+    last_send: std::time::Instant,
+    last_ack: watch::Receiver<std::time::Instant>,
+    disconnect: tokio::sync::mpsc::UnboundedSender<bool>,
+}
+
+impl HeartbeatHandler {
+    pub fn new(
+        disconnect_tx: tokio::sync::mpsc::UnboundedSender<bool>,
+    ) -> (HeartbeatHandler, HeartbeatSender) {
+        let start = std::time::Instant::now();
+        let (last_ack_tx, last_ack_rx) = watch::channel::<std::time::Instant>(start);
+        let (last_seq_tx, last_seq_rx) = watch::channel::<Option<u64>>(None);
+        let handler = HeartbeatHandler {
+            last_ack: last_ack_rx,
+            last_seq: last_seq_rx,
+            last_send: start,
+            disconnect: disconnect_tx,
+        };
+        let sender = HeartbeatSender {
+            last_ack: last_ack_tx,
+            last_seq: last_seq_tx,
+        };
+        (handler, sender)
+    }
+}
+
+pub async fn heartbeat(
+    client: tokio::sync::mpsc::UnboundedSender<gateway::Payload>,
+    heartbeat_interval: u64,
+    mut handler: HeartbeatHandler,
+) {
+    let mut interval =
+        tokio::time::interval(tokio::time::Duration::from_millis(heartbeat_interval));
+
+    loop {
+        interval.tick().await;
+
+        if *handler.last_ack.borrow() < handler.last_send {
+            // Break connection
+            log::error!("No response for heartbeat, reconnecting");
+            handler.disconnect.send(true).unwrap();
+            break;
+        }
+
+        handler.last_send = std::time::Instant::now();
+
+        log::trace!("Sending heartbeat");
+        let value: serde_json::Value = serde_json::to_value(*handler.last_seq.borrow())
+            .expect("heartbeat sequence cannot be transformed into a JSON value");
+        if let Err(e) = client.send(gateway::Payload {
+            op: gateway::GatewayOpcode::Heartbeat as u8,
+            d: value,
+            s: None,
+            t: None,
+        }) {
+            log::error!("Cannot send heartbeat to Discord: {}", e);
+        }
+    }
+}

--- a/src/gateway/socket.rs
+++ b/src/gateway/socket.rs
@@ -1,0 +1,120 @@
+use crate::api::gateway;
+use crate::errors::Result;
+use futures_util::stream::StreamExt;
+use futures_util::SinkExt;
+use websocket_lite::{AsyncClient, AsyncNetworkStream, Message};
+type WSClient = AsyncClient<Box<dyn AsyncNetworkStream + Send + Sync + Unpin>>;
+
+pub(crate) struct Client {
+    pub send: tokio::sync::mpsc::UnboundedSender<gateway::Payload>,
+    receive: tokio::sync::mpsc::UnboundedReceiver<gateway::Payload>,
+}
+
+impl Client {
+    pub fn send(&mut self, op: gateway::GatewayOpcode, value: serde_json::Value) -> Result<()> {
+        self.send.send(gateway::Payload {
+            op: op as u8,
+            d: value,
+            t: None,
+            s: None,
+        })?;
+        Ok(())
+    }
+
+    pub async fn receive(&mut self) -> Option<gateway::Payload> {
+        self.receive.recv().await
+    }
+}
+
+pub(crate) struct Connection {
+    socket: futures_util::stream::Fuse<WSClient>,
+    send: tokio::sync::mpsc::UnboundedSender<gateway::Payload>, // Linked to Client.receive
+    receive: futures_util::stream::Fuse<tokio::sync::mpsc::UnboundedReceiver<gateway::Payload>>, // Linked to Client.send
+    disconnect: futures_util::stream::Fuse<tokio::sync::mpsc::UnboundedReceiver<bool>>, // Linked to Client.send
+}
+
+impl Connection {
+    /// Creates a new Connection structure, which will be used once
+    /// to start the socket handler, and a Client structure, which
+    /// holds the queues for communication.
+    pub(crate) fn new(
+        socket: WSClient,
+        disconnect: tokio::sync::mpsc::UnboundedReceiver<bool>,
+    ) -> (Self, Client) {
+        let (client_send, receive) = tokio::sync::mpsc::unbounded_channel();
+        let (send, client_receive) = tokio::sync::mpsc::unbounded_channel();
+
+        (
+            Self {
+                send,
+                receive: receive.fuse(),
+                socket: socket.fuse(),
+                disconnect: disconnect.fuse(),
+            },
+            Client {
+                send: client_send,
+                receive: client_receive,
+            },
+        )
+    }
+
+    /// Starts the socket handling loop, and immediately returns
+    /// The handler is run through a spawned future (tokio::spawn)
+    pub(crate) fn run(mut self) {
+        tokio::spawn(async move {
+            loop {
+                futures_util::select! {
+                    disconnect = self.disconnect.select_next_some() => {
+                        if disconnect {
+                            self.socket.send(Message::close(Some((4000, String::new())))).await?;
+                            self.socket.close().await?;
+                            log::error!("Disconnecting from gateway");
+                            break;
+                        }
+                    }
+                    payload = self.socket.select_next_some() => {
+                        match payload {
+                            Ok(payload) => {
+                                log::trace!("discord raw payload {:?}", payload);
+
+                                if let Some(data) = payload.as_text() {
+                                    let payload: gateway::Payload = serde_json::from_str::<gateway::Payload>(data)?;
+                                    self.send.send(payload)?;
+                                } else {
+                                    log::error!("Discord weird payload: {:?}", payload);
+                                }
+                            }
+                            Err(e) => log::error!("Discord error: {}", e),
+                        }
+                    }
+                    payload = self.receive.select_next_some() => {
+                        send(payload, &mut self.socket).await?;
+                    }
+                }
+            }
+            Ok::<(), crate::errors::DiscordError>(())
+        });
+    }
+}
+
+async fn send(
+    mut payload: gateway::Payload,
+    socket: &mut futures_util::stream::Fuse<WSClient>,
+) -> Result<()> {
+    let payload_str = serde_json::to_string(&payload)?;
+
+    // Don't log the discord token
+    if payload.op == gateway::GatewayOpcode::Identify as u8 {
+        if let Some(token) = payload.d.get_mut("token") {
+            *token = serde_json::json!("<TOKEN REDACTED>");
+        }
+        log::trace!(
+            "sending gateway payload: {}",
+            serde_json::to_string(&payload)?
+        );
+    } else {
+        log::trace!("sending gateway payload: {}", payload_str);
+    }
+    socket.send(Message::text(payload_str)).await?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"] // For the `select` macro
+
 mod api;
 mod discord;
 mod errors;


### PR DESCRIPTION
Fixes #7
This moves handling of the websocket into a different thread, so that waiting on the messages from discord does not block the sending of messages.  This also implements the handling of HeartbeatAck messages.